### PR TITLE
Fix: Added two tests to achieve 100% branch coverage in validateQuest…

### DIFF
--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
@@ -18,6 +18,30 @@ import teammates.test.BaseTestCase;
 public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
 
     @Test
+    public void testValidateQuestionDetails_FeedbackParticipantTypeNotNone() {
+        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
+        msqDetails.setGenerateOptionsFor(FeedbackParticipantType.INSTRUCTORS);
+        
+        List<String> errors = msqDetails.validateQuestionDetails();
+
+        assertEquals(0, errors.size());
+        }
+    
+    @Test
+    public void testValidateQuestionDetails_maxSelectableChoicesLessThanTwo_errorReturn() {
+        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
+        msqDetails.setMaxSelectableChoices(0);
+        msqDetails.setOtherEnabled(false);
+        msqDetails.setMsqChoices(Arrays.asList("a","b"));
+        
+        List<String> errors = msqDetails.validateQuestionDetails();
+
+        assertEquals(1, errors.size());
+        assertEquals(FeedbackMsqQuestionDetails.MSQ_ERROR_MIN_FOR_MAX_SELECTABLE_CHOICES, errors.get(0));
+        }
+
+
+    @Test
     public void testConstructor_defaultConstructor_fieldsShouldHaveCorrectDefaultValues() {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
 


### PR DESCRIPTION
Added two test functions: testValidateQuestionDetails_FeedbackParticipantTypeNotNone and testValidateQuestionDetails_maxSelectableChoicesLessThanTwo_errorReturn that improved the branch coverage from 93% to 100%. The tests was added in the FeedbackMsqQuestionDetailsTest file. Connected to the issue #12

https://github.com/Penguinification/dd2480-teammates/issues/12
