### PR TITLE
Feat: Calculate code coverage in getRecipientsOfQuestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ This is the developer web site for TEAMMATES. **Click [here](http://teammatesv4.
 [Version History](https://github.com/TEAMMATES/teammates/milestones?direction=desc&sort=due_date&state=closed) |
 [Project Stats](https://www.openhub.net/p/teammatesonline)
 
+## Link to report
+This fork was created as a part of the DD2480 course at KTH.
+[**The report can be found here**](https://docs.google.com/document/d/18Pbn-wY31H9d7QTO26DVCbYnxxiBbLltp-C4tGSYd64/edit?usp=sharing)
+
 ## Interested to join TEAMMATES developer team?
 
 We welcome contributions from developers, especially students. Here are some resources:

--- a/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetails.java
@@ -114,57 +114,7 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
     public List<String> validateQuestionDetails() {
         List<String> errors = new ArrayList<>();
         if (generateOptionsFor == FeedbackParticipantType.NONE) {
-
-            if (msqChoices.size() < MSQ_MIN_NUM_OF_CHOICES) {
-                errors.add(MSQ_ERROR_NOT_ENOUGH_CHOICES
-                           + MSQ_MIN_NUM_OF_CHOICES + ".");
-            }
-
-            // If there are Empty Msq options entered trigger this error
-            boolean isEmptyMsqOptionEntered = msqChoices.stream().anyMatch(msqText -> "".equals(msqText.trim()));
-            if (isEmptyMsqOptionEntered) {
-                errors.add(MSQ_ERROR_EMPTY_MSQ_OPTION);
-            }
-
-            // If weights are enabled, number of choices and weights should be same.
-            // If a user enters an invalid weight for a valid choice,
-            // the msqChoices.size() will be greater than msqWeights.size(), in that case
-            // trigger this error.
-            if (hasAssignedWeights && msqChoices.size() != msqWeights.size()) {
-                errors.add(MSQ_ERROR_INVALID_WEIGHT);
-            }
-
-            // If weights are not enabled, but weight list is not empty or otherWeight is not 0
-            // In that case, trigger this error.
-            if (!hasAssignedWeights && (!msqWeights.isEmpty() || msqOtherWeight != 0)) {
-                errors.add(MSQ_ERROR_INVALID_WEIGHT);
-            }
-
-            // If weight is enabled, but other option is disabled, and msqOtherWeight is not 0
-            // In that case, trigger this error.
-            if (hasAssignedWeights && !otherEnabled && msqOtherWeight != 0) {
-                errors.add(MSQ_ERROR_INVALID_WEIGHT);
-            }
-
-            // If weights are negative, trigger this error.
-            if (hasAssignedWeights && !msqWeights.isEmpty()) {
-                msqWeights.stream()
-                        .filter(weight -> weight < 0)
-                        .forEach(weight -> errors.add(MSQ_ERROR_INVALID_WEIGHT));
-            }
-
-            // If 'Other' option is enabled, and other weight has negative value,
-            // trigger this error.
-            if (hasAssignedWeights && otherEnabled && msqOtherWeight < 0) {
-                errors.add(MSQ_ERROR_INVALID_WEIGHT);
-            }
-
-            //If there are duplicate mcq options trigger this error
-            boolean isDuplicateOptionsEntered = msqChoices.stream().map(String::trim).distinct().count()
-                                                != msqChoices.size();
-            if (isDuplicateOptionsEntered) {
-                errors.add(MSQ_ERROR_DUPLICATE_MSQ_OPTION);
-            }
+            validateMessage(errors);
         }
 
         boolean isMaxSelectableChoicesEnabled = maxSelectableChoices != Const.POINTS_NO_VALUE;
@@ -172,14 +122,18 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
         boolean isMsqChoiceValidatable = generateOptionsFor == FeedbackParticipantType.NONE;
 
         int numOfMsqChoices = msqChoices.size() + (otherEnabled ? 1 : 0);
-        if (isMsqChoiceValidatable && isMaxSelectableChoicesEnabled) {
-            if (numOfMsqChoices < maxSelectableChoices) {
-                errors.add(MSQ_ERROR_MAX_SELECTABLE_EXCEEDED_TOTAL);
-            } else if (maxSelectableChoices < 2) {
-                errors.add(MSQ_ERROR_MIN_FOR_MAX_SELECTABLE_CHOICES);
-            }
+        validateMaxSelectableChoices(isMsqChoiceValidatable, isMaxSelectableChoicesEnabled, numOfMsqChoices, errors);
+        validateMinSelectableChoices(isMsqChoiceValidatable, isMinSelectableChoicesEnabled, numOfMsqChoices, errors);
+
+        if (isMaxSelectableChoicesEnabled && isMinSelectableChoicesEnabled
+                && minSelectableChoices > maxSelectableChoices) {
+            errors.add(MSQ_ERROR_MIN_SELECTABLE_EXCEEDED_MAX_SELECTABLE);
         }
 
+        return errors;
+    }
+
+    public void validateMinSelectableChoices(boolean isMsqChoiceValidatable, boolean isMinSelectableChoicesEnabled, int numOfMsqChoices, List<String> errors){
         if (isMsqChoiceValidatable && isMinSelectableChoicesEnabled) {
             if (minSelectableChoices < 1) {
                 errors.add(MSQ_ERROR_MIN_FOR_MIN_SELECTABLE_CHOICES);
@@ -188,13 +142,70 @@ public class FeedbackMsqQuestionDetails extends FeedbackQuestionDetails {
                 errors.add(MSQ_ERROR_MIN_SELECTABLE_MORE_THAN_NUM_CHOICES);
             }
         }
+    }
 
-        if (isMaxSelectableChoicesEnabled && isMinSelectableChoicesEnabled
-                && minSelectableChoices > maxSelectableChoices) {
-            errors.add(MSQ_ERROR_MIN_SELECTABLE_EXCEEDED_MAX_SELECTABLE);
+    public void validateMaxSelectableChoices(boolean isMsqChoiceValidatable, boolean isMaxSelectableChoicesEnabled, int numOfMsqChoices, List<String> errors){
+        if (isMsqChoiceValidatable && isMaxSelectableChoicesEnabled) {
+            if (numOfMsqChoices < maxSelectableChoices) {
+                errors.add(MSQ_ERROR_MAX_SELECTABLE_EXCEEDED_TOTAL);
+            } else if (maxSelectableChoices < 2) {
+                errors.add(MSQ_ERROR_MIN_FOR_MAX_SELECTABLE_CHOICES);
+            }
+        }
+    }
+
+    public void validateMessage(List<String> errors){
+        if (msqChoices.size() < MSQ_MIN_NUM_OF_CHOICES) {
+            errors.add(MSQ_ERROR_NOT_ENOUGH_CHOICES
+                       + MSQ_MIN_NUM_OF_CHOICES + ".");
         }
 
-        return errors;
+        // If there are Empty Msq options entered trigger this error
+        boolean isEmptyMsqOptionEntered = msqChoices.stream().anyMatch(msqText -> "".equals(msqText.trim()));
+        if (isEmptyMsqOptionEntered) {
+            errors.add(MSQ_ERROR_EMPTY_MSQ_OPTION);
+        }
+
+        // If weights are enabled, number of choices and weights should be same.
+        // If a user enters an invalid weight for a valid choice,
+        // the msqChoices.size() will be greater than msqWeights.size(), in that case
+        // trigger this error.
+        if (hasAssignedWeights && msqChoices.size() != msqWeights.size()) {
+            errors.add(MSQ_ERROR_INVALID_WEIGHT);
+        }
+
+        // If weights are not enabled, but weight list is not empty or otherWeight is not 0
+        // In that case, trigger this error.
+        if (!hasAssignedWeights && (!msqWeights.isEmpty() || msqOtherWeight != 0)) {
+            errors.add(MSQ_ERROR_INVALID_WEIGHT);
+        }
+
+        // If weight is enabled, but other option is disabled, and msqOtherWeight is not 0
+        // In that case, trigger this error.
+        if (hasAssignedWeights && !otherEnabled && msqOtherWeight != 0) {
+            errors.add(MSQ_ERROR_INVALID_WEIGHT);
+        }
+
+        // If weights are negative, trigger this error.
+        if (hasAssignedWeights && !msqWeights.isEmpty()) {
+            msqWeights.stream()
+                    .filter(weight -> weight < 0)
+                    .forEach(weight -> errors.add(MSQ_ERROR_INVALID_WEIGHT));
+        }
+
+        // If 'Other' option is enabled, and other weight has negative value,
+        // trigger this error.
+        if (hasAssignedWeights && otherEnabled && msqOtherWeight < 0) {
+            errors.add(MSQ_ERROR_INVALID_WEIGHT);
+        }
+
+        //If there are duplicate mcq options trigger this error
+        boolean isDuplicateOptionsEntered = msqChoices.stream().map(String::trim).distinct().count()
+                                            != msqChoices.size();
+        if (isDuplicateOptionsEntered) {
+            errors.add(MSQ_ERROR_DUPLICATE_MSQ_OPTION);
+        }
+
     }
 
     @Override

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -280,6 +280,13 @@ public final class FeedbackQuestionsLogic {
     }
 
     /**
+     * Branch coverage tool for getRecipientsOfQuestion
+     * Do not merge!
+     */ 
+    // Create data structures to hold coverage information    
+    public final Set<Integer> debugReachedBranches = new HashSet<>();
+
+    /**
      * Gets the recipients of a feedback question including recipient section and team.
      *
      * @param question the feedback question
@@ -288,10 +295,13 @@ public final class FeedbackQuestionsLogic {
      * @param courseRoster if provided, the function can be completed without touching database
      * @return a Map of {@code FeedbackQuestionRecipient} as the value and identifier as the key.
      */
+
     public Map<String, FeedbackQuestionRecipient> getRecipientsOfQuestion(
             FeedbackQuestionAttributes question,
             @Nullable InstructorAttributes instructorGiver, @Nullable StudentAttributes studentGiver,
             @Nullable CourseRoster courseRoster) {
+        debugReachedBranches.add(1);                
+
         assert instructorGiver != null || studentGiver != null;
 
         Map<String, FeedbackQuestionRecipient> recipients = new HashMap<>();
@@ -303,13 +313,17 @@ public final class FeedbackQuestionsLogic {
         String giverTeam = "";
         String giverSection = "";
         if (isStudentGiver) {
+            debugReachedBranches.add(2);        
             giverEmail = studentGiver.getEmail();
             giverTeam = studentGiver.getTeam();
             giverSection = studentGiver.getSection();
         } else if (isInstructorGiver) {
+            debugReachedBranches.add(3);
             giverEmail = instructorGiver.getEmail();
             giverTeam = Const.USER_TEAM_FOR_INSTRUCTOR;
             giverSection = Const.DEFAULT_SECTION;
+        } else  {
+            debugReachedBranches.add(4);
         }
 
         FeedbackParticipantType recipientType = question.getRecipientType();
@@ -317,10 +331,13 @@ public final class FeedbackQuestionsLogic {
 
         switch (recipientType) {
         case SELF:
+            debugReachedBranches.add(5);
             if (question.getGiverType() == FeedbackParticipantType.TEAMS) {
+                debugReachedBranches.add(6);
                 recipients.put(giverTeam,
                        new FeedbackQuestionRecipient(giverTeam, giverTeam));
             } else {
+                debugReachedBranches.add(7);
                 recipients.put(giverEmail,
                         new FeedbackQuestionRecipient(USER_NAME_FOR_SELF, giverEmail));
             }
@@ -328,133 +345,185 @@ public final class FeedbackQuestionsLogic {
         case STUDENTS:
         case STUDENTS_EXCLUDING_SELF:
         case STUDENTS_IN_SAME_SECTION:
+            debugReachedBranches.add(8);
             List<StudentAttributes> studentList;
             if (courseRoster == null) {
+                debugReachedBranches.add(9);
                 if (generateOptionsFor == FeedbackParticipantType.STUDENTS_IN_SAME_SECTION) {
+                    debugReachedBranches.add(10);
                     studentList = studentsLogic.getStudentsForSection(giverSection, question.getCourseId());
                 } else {
+                    debugReachedBranches.add(11);
                     studentList = studentsLogic.getStudentsForCourse(question.getCourseId());
                 }
             } else {
+                debugReachedBranches.add(12);
                 if (generateOptionsFor == FeedbackParticipantType.STUDENTS_IN_SAME_SECTION) {
+                    debugReachedBranches.add(13);
                     final String finalGiverSection = giverSection;
                     studentList = courseRoster.getStudents().stream()
                             .filter(studentAttributes -> studentAttributes.getSection()
                                     .equals(finalGiverSection)).collect(Collectors.toList());
                 } else {
+                    debugReachedBranches.add(14);
                     studentList = courseRoster.getStudents();
                 }
             }
             for (StudentAttributes student : studentList) {
+                debugReachedBranches.add(15);
                 if (isInstructorGiver && !instructorGiver.isAllowedForPrivilege(
                         student.getSection(), question.getFeedbackSessionName(),
                         Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS)) {
+                    debugReachedBranches.add(16);
                     // instructor can only see students in allowed sections for him/her
                     continue;
+                } else {
+                    debugReachedBranches.add(17);
                 }
                 // Ensure student does not evaluate him/herself if it's STUDENTS_EXCLUDING_SELF or
                 // STUDENTS_IN_SAME_SECTION
                 if (giverEmail.equals(student.getEmail()) && generateOptionsFor != FeedbackParticipantType.STUDENTS) {
+                    debugReachedBranches.add(18);
                     continue;
+                } else {
+                    debugReachedBranches.add(19);
                 }
                 recipients.put(student.getEmail(), new FeedbackQuestionRecipient(student.getName(), student.getEmail(),
                         student.getSection(), student.getTeam()));
             }
             break;
         case INSTRUCTORS:
+            debugReachedBranches.add(20);
             List<InstructorAttributes> instructorsInCourse;
             if (courseRoster == null) {
+                debugReachedBranches.add(21);
                 instructorsInCourse = instructorsLogic.getInstructorsForCourse(question.getCourseId());
             } else {
+                debugReachedBranches.add(22);
                 instructorsInCourse = courseRoster.getInstructors();
             }
             for (InstructorAttributes instr : instructorsInCourse) {
+                debugReachedBranches.add(23);
                 // remove hidden instructors for students
                 if (isStudentGiver && !instr.isDisplayedToStudents()) {
+                    debugReachedBranches.add(24);
                     continue;
+                } else {
+                    debugReachedBranches.add(25);
                 }
                 // Ensure instructor does not evaluate himself
                 if (!giverEmail.equals(instr.getEmail())) {
+                    debugReachedBranches.add(26);
                     recipients.put(instr.getEmail(),
                             new FeedbackQuestionRecipient(instr.getName(), instr.getEmail()));
+                } else {
+                    debugReachedBranches.add(27);
                 }
             }
             break;
         case TEAMS:
         case TEAMS_EXCLUDING_SELF:
         case TEAMS_IN_SAME_SECTION:
+            debugReachedBranches.add(28);
             Map<String, List<StudentAttributes>> teamToTeamMembersTable;
             List<StudentAttributes> teamStudents;
             if (courseRoster == null) {
+                debugReachedBranches.add(29);
                 if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
+                    debugReachedBranches.add(30);
                     teamStudents = studentsLogic.getStudentsForSection(giverSection, question.getCourseId());
                 } else {
+                    debugReachedBranches.add(31);
                     teamStudents = studentsLogic.getStudentsForCourse(question.getCourseId());
                 }
                 teamToTeamMembersTable = CourseRoster.buildTeamToMembersTable(teamStudents);
             } else {
+                debugReachedBranches.add(32);
                 if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
+                    debugReachedBranches.add(33);
                     final String finalGiverSection = giverSection;
                     teamStudents = courseRoster.getStudents().stream()
                             .filter(student -> student.getSection().equals(finalGiverSection))
                             .collect(Collectors.toList());
                     teamToTeamMembersTable = CourseRoster.buildTeamToMembersTable(teamStudents);
                 } else {
+                    debugReachedBranches.add(34);
                     teamToTeamMembersTable = courseRoster.getTeamToMembersTable();
                 }
             }
             for (Map.Entry<String, List<StudentAttributes>> team : teamToTeamMembersTable.entrySet()) {
+                debugReachedBranches.add(35);
                 if (isInstructorGiver && !instructorGiver.isAllowedForPrivilege(
                         team.getValue().iterator().next().getSection(),
                         question.getFeedbackSessionName(),
                         Const.InstructorPermissions.CAN_SUBMIT_SESSION_IN_SECTIONS)) {
+                    debugReachedBranches.add(36);
                     // instructor can only see teams in allowed sections for him/her
                     continue;
+                } else {
+                    debugReachedBranches.add(37);
                 }
                 // Ensure student('s team) does not evaluate own team if it's TEAMS_EXCLUDING_SELF or
                 // TEAMS_IN_SAME_SECTION
                 if (giverTeam.equals(team.getKey()) && generateOptionsFor != FeedbackParticipantType.TEAMS) {
+                    debugReachedBranches.add(38);
                     continue;
+                } else {
+                    debugReachedBranches.add(39);
                 }
                 // recipientEmail doubles as team name in this case.
                 recipients.put(team.getKey(), new FeedbackQuestionRecipient(team.getKey(), team.getKey()));
             }
             break;
         case OWN_TEAM:
+            debugReachedBranches.add(40);
             recipients.put(giverTeam, new FeedbackQuestionRecipient(giverTeam, giverTeam));
             break;
         case OWN_TEAM_MEMBERS:
+            debugReachedBranches.add(41);
             List<StudentAttributes> students;
             if (courseRoster == null) {
+                debugReachedBranches.add(42);
                 students = studentsLogic.getStudentsForTeam(giverTeam, question.getCourseId());
             } else {
+                debugReachedBranches.add(43);
                 students = courseRoster.getTeamToMembersTable().getOrDefault(giverTeam, Collections.emptyList());
             }
             for (StudentAttributes student : students) {
+                debugReachedBranches.add(44);
                 if (!student.getEmail().equals(giverEmail)) {
+                    debugReachedBranches.add(45);
                     recipients.put(student.getEmail(), new FeedbackQuestionRecipient(student.getName(), student.getEmail(),
                             student.getSection(), student.getTeam()));
+                } else {
+                    debugReachedBranches.add(46);
                 }
             }
             break;
         case OWN_TEAM_MEMBERS_INCLUDING_SELF:
+            debugReachedBranches.add(47);
             List<StudentAttributes> teamMembers;
             if (courseRoster == null) {
+                debugReachedBranches.add(48);
                 teamMembers = studentsLogic.getStudentsForTeam(giverTeam, question.getCourseId());
             } else {
+                debugReachedBranches.add(49);
                 teamMembers = courseRoster.getTeamToMembersTable().getOrDefault(giverTeam, Collections.emptyList());
             }
             for (StudentAttributes student : teamMembers) {
+                debugReachedBranches.add(50);
                 // accepts self feedback too
                 recipients.put(student.getEmail(), new FeedbackQuestionRecipient(student.getName(), student.getEmail(),
                         student.getSection(), student.getTeam()));
             }
             break;
         case NONE:
+            debugReachedBranches.add(51);
             recipients.put(Const.GENERAL_QUESTION,
                     new FeedbackQuestionRecipient(Const.GENERAL_QUESTION, Const.GENERAL_QUESTION));
             break;
         default:
+            debugReachedBranches.add(52);
             break;
         }
         return recipients;

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -572,14 +572,13 @@ public final class FeedbackQuestionsLogic {
 
         FeedbackParticipantType generateOptionsFor;
 
+        // Create optionsList and generateOptionsFor
         if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MCQ) {
-            FeedbackMcqQuestionDetails feedbackMcqQuestionDetails =
-                    (FeedbackMcqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
+            FeedbackMcqQuestionDetails feedbackMcqQuestionDetails = (FeedbackMcqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
             optionList = feedbackMcqQuestionDetails.getMcqChoices();
             generateOptionsFor = feedbackMcqQuestionDetails.getGenerateOptionsFor();
         } else if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MSQ) {
-            FeedbackMsqQuestionDetails feedbackMsqQuestionDetails =
-                    (FeedbackMsqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
+            FeedbackMsqQuestionDetails feedbackMsqQuestionDetails = (FeedbackMsqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
             optionList = feedbackMsqQuestionDetails.getMsqChoices();
             generateOptionsFor = feedbackMsqQuestionDetails.getGenerateOptionsFor();
         } else {
@@ -587,68 +586,67 @@ public final class FeedbackQuestionsLogic {
             return;
         }
 
-        switch (generateOptionsFor) {
+        populateOptionList(optionList, generateOptionsFor, feedbackQuestionAttributes, emailOfEntityDoingQuestion, teamOfEntityDoingQuestion);
+
+        // Write optionList to feedbackQuestionAttributes
+        if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MCQ) {
+            FeedbackMcqQuestionDetails feedbackMcqQuestionDetails = (FeedbackMcqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
+            feedbackMcqQuestionDetails.setMcqChoices(optionList);
+            feedbackQuestionAttributes.setQuestionDetails(feedbackMcqQuestionDetails);
+        } else if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MSQ) {
+            FeedbackMsqQuestionDetails feedbackMsqQuestionDetails = (FeedbackMsqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
+            feedbackMsqQuestionDetails.setMsqChoices(optionList);
+            feedbackQuestionAttributes.setQuestionDetails(feedbackMsqQuestionDetails);
+        }
+    }
+
+    /**
+     * Helper function for populateFieldsToGenerateInQuestion that populates the given optionList
+     * @param optionList the optionList to populate
+     * @param generateOptionsFor the type of feedback participant to generate options for
+     * @param feedbackQuestionAttributes the question to populate
+     * @param emailOfEntityDoingQuestion the email of the entity doing the question
+     * @param teamOfEntityDoingQuestion the team of the entity doing the question.
+     * @throws AssertionError if the course specified in the feedback question attributes does not exist
+     * or when generateOptionsFor is neither a student, team or instructor
+     */
+    private void populateOptionList(
+        List<String> optionList,
+        FeedbackParticipantType generateOptionsFor,
+        FeedbackQuestionAttributes feedbackQuestionAttributes,
+        String emailOfEntityDoingQuestion,
+        String teamOfEntityDoingQuestion
+    ) {
+    switch (generateOptionsFor) {
         case NONE:
             break;
         case STUDENTS:
         case STUDENTS_IN_SAME_SECTION:
         case STUDENTS_EXCLUDING_SELF:
-            List<StudentAttributes> studentList;
-            if (generateOptionsFor == FeedbackParticipantType.STUDENTS_IN_SAME_SECTION) {
-                String courseId = feedbackQuestionAttributes.getCourseId();
-                StudentAttributes studentAttributes =
-                        studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
-                studentList = studentsLogic.getStudentsForSection(studentAttributes.getSection(), courseId);
-            } else {
-                studentList = studentsLogic.getStudentsForCourse(feedbackQuestionAttributes.getCourseId());
-            }
+            List<StudentAttributes> studentList = getStudentList(generateOptionsFor, feedbackQuestionAttributes, emailOfEntityDoingQuestion);
 
-            if (generateOptionsFor == FeedbackParticipantType.STUDENTS_EXCLUDING_SELF) {
-                studentList.removeIf(studentInList -> studentInList.getEmail().equals(emailOfEntityDoingQuestion));
-            }
-
-            for (StudentAttributes student : studentList) {
+            for (StudentAttributes student : studentList)
                 optionList.add(student.getName() + " (" + student.getTeam() + ")");
-            }
 
             optionList.sort(null);
             break;
         case TEAMS:
         case TEAMS_IN_SAME_SECTION:
         case TEAMS_EXCLUDING_SELF:
-            try {
-                List<String> teams;
-                if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
-                    String courseId = feedbackQuestionAttributes.getCourseId();
-                    StudentAttributes studentAttributes =
-                            studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
-                    teams = coursesLogic.getTeamsForSection(studentAttributes.getSection(), courseId);
-                } else {
-                    teams = coursesLogic.getTeamsForCourse(feedbackQuestionAttributes.getCourseId());
-                }
+            List<String> teams = getTeamList(generateOptionsFor, feedbackQuestionAttributes, emailOfEntityDoingQuestion, teamOfEntityDoingQuestion);
 
-                if (generateOptionsFor == FeedbackParticipantType.TEAMS_EXCLUDING_SELF) {
-                    teams.removeIf(team -> team.equals(teamOfEntityDoingQuestion));
-                }
+            for (String team : teams)
+                optionList.add(team);
 
-                for (String team : teams) {
-                    optionList.add(team);
-                }
-
-                optionList.sort(null);
-            } catch (EntityDoesNotExistException e) {
-                assert false : "Course disappeared";
-            }
+            optionList.sort(null);
             break;
         case OWN_TEAM_MEMBERS_INCLUDING_SELF:
         case OWN_TEAM_MEMBERS:
             if (teamOfEntityDoingQuestion != null) {
-                List<StudentAttributes> teamMembers = studentsLogic.getStudentsForTeam(teamOfEntityDoingQuestion,
-                        feedbackQuestionAttributes.getCourseId());
+                List<StudentAttributes> teamMembers = studentsLogic.getStudentsForTeam(teamOfEntityDoingQuestion, feedbackQuestionAttributes.getCourseId());
 
-                if (generateOptionsFor == FeedbackParticipantType.OWN_TEAM_MEMBERS) {
+                if (generateOptionsFor == FeedbackParticipantType.OWN_TEAM_MEMBERS)
                     teamMembers.removeIf(teamMember -> teamMember.getEmail().equals(emailOfEntityDoingQuestion));
-                }
 
                 teamMembers.forEach(teamMember -> optionList.add(teamMember.getName()));
 
@@ -656,12 +654,10 @@ public final class FeedbackQuestionsLogic {
             }
             break;
         case INSTRUCTORS:
-            List<InstructorAttributes> instructorList =
-                    instructorsLogic.getInstructorsForCourse(feedbackQuestionAttributes.getCourseId());
+            List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForCourse(feedbackQuestionAttributes.getCourseId());
 
-            for (InstructorAttributes instructor : instructorList) {
+            for (InstructorAttributes instructor : instructorList)
                 optionList.add(instructor.getName());
-            }
 
             optionList.sort(null);
             break;
@@ -669,17 +665,67 @@ public final class FeedbackQuestionsLogic {
             assert false : "Trying to generate options for neither students, teams nor instructors";
             break;
         }
+    }
 
-        if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MCQ) {
-            FeedbackMcqQuestionDetails feedbackMcqQuestionDetails =
-                    (FeedbackMcqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
-            feedbackMcqQuestionDetails.setMcqChoices(optionList);
-            feedbackQuestionAttributes.setQuestionDetails(feedbackMcqQuestionDetails);
-        } else if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MSQ) {
-            FeedbackMsqQuestionDetails feedbackMsqQuestionDetails =
-                    (FeedbackMsqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
-            feedbackMsqQuestionDetails.setMsqChoices(optionList);
-            feedbackQuestionAttributes.setQuestionDetails(feedbackMsqQuestionDetails);
+    /**
+     * Returns a list of student names based on the given feedback participant type, feedback question attributes and email of the entity doing the question
+     * @param generateOptionsFor the type of feedback participant to generate options for
+     * @param feedbackQuestionAttributes the question to populate
+     * @param emailOfEntityDoingQuestion the email of the entity doing the question
+     * @return a list of student names
+     */
+    private List<StudentAttributes> getStudentList(
+        FeedbackParticipantType generateOptionsFor,
+        FeedbackQuestionAttributes feedbackQuestionAttributes,
+        String emailOfEntityDoingQuestion
+    ) {
+        List<StudentAttributes> studentList;
+        if (generateOptionsFor == FeedbackParticipantType.STUDENTS_IN_SAME_SECTION) {
+            String courseId = feedbackQuestionAttributes.getCourseId();
+            StudentAttributes studentAttributes =
+                    studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
+            studentList = studentsLogic.getStudentsForSection(studentAttributes.getSection(), courseId);
+        } else
+            studentList = studentsLogic.getStudentsForCourse(feedbackQuestionAttributes.getCourseId());
+
+        if (generateOptionsFor == FeedbackParticipantType.STUDENTS_EXCLUDING_SELF)
+            studentList.removeIf(studentInList -> studentInList.getEmail().equals(emailOfEntityDoingQuestion));
+        return studentList;
+    }
+
+    /**
+     * Returns a list of team names based on the given feedback participant type, feedback question attributes, email of the entity doing the question,
+     * and team of the entity doing the question.
+     * @param generateOptionsFor the type of feedback participant to generate options for
+     * @param feedbackQuestionAttributes the question to populate
+     * @param emailOfEntityDoingQuestion the email of the entity doing the question
+     * @param teamOfEntityDoingQuestion the team of the entity doing the question.
+     * @return a list of team names
+     * @throws AssertionError if the course specified in the feedback question attributes does not exist
+     */
+    private List<String> getTeamList(
+        FeedbackParticipantType generateOptionsFor,
+        FeedbackQuestionAttributes feedbackQuestionAttributes,
+        String emailOfEntityDoingQuestion,
+        String teamOfEntityDoingQuestion
+    ) {
+        try {
+            List<String> teams;
+            if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
+                String courseId = feedbackQuestionAttributes.getCourseId();
+                StudentAttributes studentAttributes =
+                        studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
+                teams = coursesLogic.getTeamsForSection(studentAttributes.getSection(), courseId);
+            } else
+                teams = coursesLogic.getTeamsForCourse(feedbackQuestionAttributes.getCourseId());
+
+            if (generateOptionsFor == FeedbackParticipantType.TEAMS_EXCLUDING_SELF)
+                teams.removeIf(team -> team.equals(teamOfEntityDoingQuestion));
+            
+            return teams;
+        } catch (EntityDoesNotExistException e) {
+            assert false : "Course disappeared";
+            return Collections.emptyList(); // Unreachable
         }
     }
 

--- a/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackResponsesLogic.java
@@ -49,6 +49,8 @@ public final class FeedbackResponsesLogic {
     private InstructorsLogic instructorsLogic;
     private StudentsLogic studentsLogic;
 
+    public Integer[] debugReachedBranches;
+
     private FeedbackResponsesLogic() {
         // prevent initialization
     }

--- a/src/test/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributesTest.java
@@ -824,23 +824,40 @@ public class FeedbackQuestionAttributesTest extends BaseAttributesTest {
         FeedbackQuestionAttributes feedbackQuestionNull = null;
         FeedbackQuestionAttributes feedbackQuestion = getNewFeedbackQuestionAttributes();
 
-        assertFalse(feedbackQuestion.equals(feedbackQuestionNull));
+        assertFalse(feedbackQuestion.equals(feedbackQuestionNull));   
+    }
 
-        feedbackQuestionNull = getNewFeedbackQuestionAttributes();
-        feedbackQuestion = getNewFeedbackQuestionAttributes();
+    @Test
+    public void testEqualsNull_questionDescription() {
+        FeedbackQuestionAttributes feedbackQuestionNull = getNewFeedbackQuestionAttributes();
+        FeedbackQuestionAttributes feedbackQuestion = getNewFeedbackQuestionAttributes();
 
-        feedbackQuestionNull.setFeedbackSessionName(null);
-        feedbackQuestion.setFeedbackSessionName("Some session name");
+        feedbackQuestionNull.setQuestionDescription(null);
+        feedbackQuestion.setQuestionDescription("Some description");
 
-        assertFalse(feedbackQuestion.equals(feedbackQuestionNull));
+        assertFalse(feedbackQuestionNull.equals(feedbackQuestion));
+    }
 
-        feedbackQuestionNull = getNewFeedbackQuestionAttributes();
-        feedbackQuestion = getNewFeedbackQuestionAttributes();
+    @Test
+    public void testEqualsNull_courseId() {
+        FeedbackQuestionAttributes feedbackQuestionNull = getNewFeedbackQuestionAttributes();
+        FeedbackQuestionAttributes feedbackQuestion = getNewFeedbackQuestionAttributes();
 
         feedbackQuestionNull.setCourseId(null);
         feedbackQuestion.setCourseId("Some courseId");
 
         assertFalse(feedbackQuestion.equals(feedbackQuestionNull));
+    }
+
+    @Test
+    public void testEqualsNull_feedbackSessionName() {
+        FeedbackQuestionAttributes feedbackQuestionNull = getNewFeedbackQuestionAttributes();
+        FeedbackQuestionAttributes feedbackQuestion = getNewFeedbackQuestionAttributes();
+
+        feedbackQuestionNull.setFeedbackSessionName(null);
+        feedbackQuestion.setFeedbackSessionName("Some session name");
+
+        assertFalse(feedbackQuestionNull.equals(feedbackQuestion));
     }
 
     @Test
@@ -873,7 +890,21 @@ public class FeedbackQuestionAttributesTest extends BaseAttributesTest {
                 .build();
 
         assertFalse(feedbackQuestion.equals(feedbackQuestionDifferent));
+    }
 
+    @Test
+    public void testEquals_recipientType() {
+        FeedbackQuestionAttributes feedbackQuestionOne = getNewFeedbackQuestionAttributes();
+        FeedbackQuestionAttributes feedbackQuestionTwo = getNewFeedbackQuestionAttributes();
+
+        feedbackQuestionOne.setRecipientType(FeedbackParticipantType.INSTRUCTORS);
+        feedbackQuestionTwo.setRecipientType(FeedbackParticipantType.GIVER);
+
+        assertFalse(feedbackQuestionOne.equals(feedbackQuestionTwo));
+
+        feedbackQuestionOne.setRecipientType(FeedbackParticipantType.GIVER);
+
+        assertTrue(feedbackQuestionOne.equals(feedbackQuestionTwo));
     }
 
     @Test

--- a/src/test/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributesTest.java
+++ b/src/test/java/teammates/common/datatransfer/attributes/FeedbackQuestionAttributesTest.java
@@ -820,6 +820,63 @@ public class FeedbackQuestionAttributesTest extends BaseAttributesTest {
     }
 
     @Test
+    public void testEqualsNull() {
+        FeedbackQuestionAttributes feedbackQuestionNull = null;
+        FeedbackQuestionAttributes feedbackQuestion = getNewFeedbackQuestionAttributes();
+
+        assertFalse(feedbackQuestion.equals(feedbackQuestionNull));
+
+        feedbackQuestionNull = getNewFeedbackQuestionAttributes();
+        feedbackQuestion = getNewFeedbackQuestionAttributes();
+
+        feedbackQuestionNull.setFeedbackSessionName(null);
+        feedbackQuestion.setFeedbackSessionName("Some session name");
+
+        assertFalse(feedbackQuestion.equals(feedbackQuestionNull));
+
+        feedbackQuestionNull = getNewFeedbackQuestionAttributes();
+        feedbackQuestion = getNewFeedbackQuestionAttributes();
+
+        feedbackQuestionNull.setCourseId(null);
+        feedbackQuestion.setCourseId("Some courseId");
+
+        assertFalse(feedbackQuestion.equals(feedbackQuestionNull));
+    }
+
+    @Test
+    public void testEqualsNegative() {
+        FeedbackQuestionAttributes feedbackQuestion = FeedbackQuestionAttributes.builder()
+                .withGiverType(FeedbackParticipantType.INSTRUCTORS)
+                .build();
+        FeedbackQuestionAttributes feedbackQuestionDifferent = FeedbackQuestionAttributes.builder()
+                .withGiverType(FeedbackParticipantType.OWN_TEAM)
+                .build();
+
+        assertFalse(feedbackQuestion.equals(feedbackQuestionDifferent));
+
+        feedbackQuestion = FeedbackQuestionAttributes.builder()
+                .withNumberOfEntitiesToGiveFeedbackTo(10)
+                .build();
+
+        feedbackQuestionDifferent = FeedbackQuestionAttributes.builder()
+                .withNumberOfEntitiesToGiveFeedbackTo(20)
+                .build();
+
+        assertFalse(feedbackQuestion.equals(feedbackQuestionDifferent));
+
+        feedbackQuestion = FeedbackQuestionAttributes.builder()
+                .withQuestionNumber(6)
+                .build();
+
+        feedbackQuestionDifferent = FeedbackQuestionAttributes.builder()
+                .withQuestionNumber(5)
+                .build();
+
+        assertFalse(feedbackQuestion.equals(feedbackQuestionDifferent));
+
+    }
+
+    @Test
     public void testHashCode() {
         FeedbackQuestionAttributes feedbackQuestion = getNewFeedbackQuestionAttributes();
 

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
@@ -38,8 +38,67 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
 
         assertEquals(1, errors.size());
         assertEquals(FeedbackMsqQuestionDetails.MSQ_ERROR_MIN_FOR_MAX_SELECTABLE_CHOICES, errors.get(0));
-        }
+    }
 
+     //Branch: this.minSelectableChoices and newMsqDetails.minSelectableChoices are both Const.POINTS_NO_VALUE.
+     @Test
+     public void testShouldChangesRequireResponseDeletion_moreStrictMinRestriction_BothMsqDetalsAndnewMsqDetailsNoValue_shouldReturnTrue() {
+         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
+         msqDetails.setMinSelectableChoices(Const.POINTS_NO_VALUE);
+ 
+         FeedbackMsqQuestionDetails newMsqDetails = new FeedbackMsqQuestionDetails();
+         newMsqDetails.setMinSelectableChoices(Const.POINTS_NO_VALUE);
+ 
+         assertFalse(msqDetails.shouldChangesRequireResponseDeletion(newMsqDetails));
+     }
+ 
+     //Branch: this.minSelectableChoices is not Const.POINTS_NO_VALUE, and newMsqDetails.minSelectableChoices is.
+     @Test
+     public void testShouldChangesRequireResponseDeletion_moreStrictMinRestriction_MsqDetailsNotNovalue_shouldReturnTrue() {
+         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
+         msqDetails.setMinSelectableChoices(3);
+     
+         FeedbackMsqQuestionDetails newMsqDetails = new FeedbackMsqQuestionDetails();
+         newMsqDetails.setMinSelectableChoices(Const.POINTS_NO_VALUE);
+     
+         assertFalse(msqDetails.shouldChangesRequireResponseDeletion(newMsqDetails));
+     }  
+     
+     //Branch Both this.minSelectableChoices and newMsqDetails.minSelectableChoices are not Const.POINTS_NO_VALUE, but this.minSelectableChoices is greater than or equal to newMsqDetails.minSelectableChoices.
+     @Test
+     public void testShouldChangesRequireResponseDeletion_moreStrictMinRestriction_msqDetailsSelectableChoiesGreaterThan_newMsqDetals_shouldReturnTrue() {
+         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
+         msqDetails.setMinSelectableChoices(20);
+     
+         FeedbackMsqQuestionDetails newMsqDetails = new FeedbackMsqQuestionDetails();
+         newMsqDetails.setMinSelectableChoices(5);
+     
+         assertFalse(msqDetails.shouldChangesRequireResponseDeletion(newMsqDetails));
+     }  
+ 
+     // Maybe delete? 
+     @Test
+     public void testShouldChangesRequireResponseDeletion_moreStrictMinRestriction_minSelectableChoicesEqual_shouldReturnTrue() {
+         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
+         msqDetails.setMinSelectableChoices(3);
+     
+         FeedbackMsqQuestionDetails newMsqDetails = new FeedbackMsqQuestionDetails();
+         newMsqDetails.setMinSelectableChoices(3);
+     
+         assertFalse(msqDetails.shouldChangesRequireResponseDeletion(newMsqDetails));
+     } 
+ 
+     // this.msqChoices.size() != newMsqDetails.msqChoices.size() [1/2 branches covered]
+     @Test
+     public void testShouldChangesRequireResponseDeletion_differentSizesMsqChoices_shouldReturnTrue() {
+         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
+         msqDetails.setMsqChoices(List.of("choice1", "choice2"));
+ 
+         FeedbackMsqQuestionDetails newMsqDetails = new FeedbackMsqQuestionDetails();
+         newMsqDetails.setMsqChoices(List.of("choice1"));
+ 
+         assertTrue(msqDetails.shouldChangesRequireResponseDeletion(newMsqDetails));
+     }
 
     @Test
     public void testConstructor_defaultConstructor_fieldsShouldHaveCorrectDefaultValues() {

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
@@ -18,6 +18,30 @@ import teammates.test.BaseTestCase;
 public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
 
     @Test
+    public void testValidateQuestionDetails_FeedbackParticipantTypeNotNone() {
+        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
+        msqDetails.setGenerateOptionsFor(FeedbackParticipantType.INSTRUCTORS);
+        
+        List<String> errors = msqDetails.validateQuestionDetails();
+
+        assertEquals(0, errors.size());
+        }
+    
+    @Test
+    public void testValidateQuestionDetails_maxSelectableChoicesLessThanTwo_errorReturn() {
+        FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
+        msqDetails.setMaxSelectableChoices(0);
+        msqDetails.setOtherEnabled(false);
+        msqDetails.setMsqChoices(Arrays.asList("a","b"));
+        
+        List<String> errors = msqDetails.validateQuestionDetails();
+
+        assertEquals(1, errors.size());
+        assertEquals(FeedbackMsqQuestionDetails.MSQ_ERROR_MIN_FOR_MAX_SELECTABLE_CHOICES, errors.get(0));
+        }
+
+
+    @Test
     public void testConstructor_defaultConstructor_fieldsShouldHaveCorrectDefaultValues() {
         FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
 

--- a/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
+++ b/src/test/java/teammates/common/datatransfer/questions/FeedbackMsqQuestionDetailsTest.java
@@ -40,7 +40,6 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
         assertEquals(FeedbackMsqQuestionDetails.MSQ_ERROR_MIN_FOR_MAX_SELECTABLE_CHOICES, errors.get(0));
     }
 
-     //Branch: this.minSelectableChoices and newMsqDetails.minSelectableChoices are both Const.POINTS_NO_VALUE.
      @Test
      public void testShouldChangesRequireResponseDeletion_moreStrictMinRestriction_BothMsqDetalsAndnewMsqDetailsNoValue_shouldReturnTrue() {
          FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
@@ -52,7 +51,6 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
          assertFalse(msqDetails.shouldChangesRequireResponseDeletion(newMsqDetails));
      }
  
-     //Branch: this.minSelectableChoices is not Const.POINTS_NO_VALUE, and newMsqDetails.minSelectableChoices is.
      @Test
      public void testShouldChangesRequireResponseDeletion_moreStrictMinRestriction_MsqDetailsNotNovalue_shouldReturnTrue() {
          FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
@@ -64,7 +62,6 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
          assertFalse(msqDetails.shouldChangesRequireResponseDeletion(newMsqDetails));
      }  
      
-     //Branch Both this.minSelectableChoices and newMsqDetails.minSelectableChoices are not Const.POINTS_NO_VALUE, but this.minSelectableChoices is greater than or equal to newMsqDetails.minSelectableChoices.
      @Test
      public void testShouldChangesRequireResponseDeletion_moreStrictMinRestriction_msqDetailsSelectableChoiesGreaterThan_newMsqDetals_shouldReturnTrue() {
          FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
@@ -76,7 +73,6 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
          assertFalse(msqDetails.shouldChangesRequireResponseDeletion(newMsqDetails));
      }  
  
-     // Maybe delete? 
      @Test
      public void testShouldChangesRequireResponseDeletion_moreStrictMinRestriction_minSelectableChoicesEqual_shouldReturnTrue() {
          FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();
@@ -88,7 +84,6 @@ public class FeedbackMsqQuestionDetailsTest extends BaseTestCase {
          assertFalse(msqDetails.shouldChangesRequireResponseDeletion(newMsqDetails));
      } 
  
-     // this.msqChoices.size() != newMsqDetails.msqChoices.size() [1/2 branches covered]
      @Test
      public void testShouldChangesRequireResponseDeletion_differentSizesMsqChoices_shouldReturnTrue() {
          FeedbackMsqQuestionDetails msqDetails = new FeedbackMsqQuestionDetails();

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -57,6 +57,37 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         removeAndRestoreTypicalDataBundle();
     }
 
+    //Aggregated result from all tests of the class will be stored in this datastructure
+    private static Set<Integer> debugReachedBranches = new HashSet<Integer>();
+    
+    @AfterTest
+    public void afterTest() {
+        int coveredBranches = fqLogic.debugReachedBranches.size();
+        double totalBranches = 52;
+        Double branchCoverage = 100 * ((double) coveredBranches / totalBranches);
+        System.out.println("From aftertest: " + coveredBranches);
+        try {
+                File directory = new File("./build/reports/tests/coverage");
+                directory.mkdirs();
+                FileWriter writer = new FileWriter("./build/reports/tests/coverage/getRecipientsOfQuestion.txt");
+                writer.write("Code coverage: " + branchCoverage.toString() + "%\n");
+                writer.write("Branches covered: ");
+                for (Integer i : frLogic.debugReachedBranches) {
+                        writer.write(i.toString() + " ");
+                }
+                writer.write("\nBranches not covered: ");
+                for (Integer i = 1; i < totalBranches; i++) {
+                        if (!Arrays.asList(frLogic.debugReachedBranches).contains(i)) {
+                                writer.write(i.toString() + " ");
+                        }
+                }
+                writer.write("\n");
+                writer.close();
+        } catch (IOException e) {
+                e.printStackTrace();
+        }
+    }    
+    
     @Test
     public void testDeleteFeedbackQuestions_byCourseIdAndSessionName_shouldDeleteQuestions() {
         FeedbackSessionAttributes fsa = dataBundle.feedbackSessions.get("session1InCourse1");
@@ -90,34 +121,6 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         testAddQuestion();
     }
 
-
-    @AfterTest
-    public void afterTest() {
-        int coveredBranches = fqLogic.debugReachedBranches.size();
-        double totalBranches = 52;
-        Double branchCoverage = 100 * ((double) coveredBranches / totalBranches);
-        System.out.println("From aftertest: " + coveredBranches);
-        try {
-                File directory = new File("./build/reports/tests/coverage");
-                directory.mkdirs();
-                FileWriter writer = new FileWriter("./build/reports/tests/coverage/getRecipientsOfQuestion.txt");
-                writer.write("Code coverage: " + branchCoverage.toString() + "%\n");
-                writer.write("Branches covered: ");
-                for (Integer i : frLogic.debugReachedBranches) {
-                        writer.write(i.toString() + " ");
-                }
-                writer.write("\nBranches not covered: ");
-                for (Integer i = 1; i < totalBranches; i++) {
-                        if (!Arrays.asList(frLogic.debugReachedBranches).contains(i)) {
-                                writer.write(i.toString() + " ");
-                        }
-                }
-                writer.write("\n");
-                writer.close();
-        } catch (IOException e) {
-                e.printStackTrace();
-        }
-    }    
 
     @Test
     public void testGetRecipientsOfQuestion() throws Exception {

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -94,7 +94,7 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
     @AfterTest
     public void afterTest() {
         int coveredBranches = fqLogic.debugReachedBranches.size();
-        double totalBranches = 44;
+        double totalBranches = 52;
         Double branchCoverage = 100 * ((double) coveredBranches / totalBranches);
         System.out.println("From aftertest: " + coveredBranches);
         try {

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -6,9 +6,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.testng.annotations.AfterTest;
 
 import teammates.common.datatransfer.AttributesDeletionQuery;
 import teammates.common.datatransfer.CourseRoster;
@@ -85,6 +89,35 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         testGetFeedbackQuestionsForStudents();
         testAddQuestion();
     }
+
+
+    @AfterTest
+    public void afterTest() {
+        int coveredBranches = fqLogic.debugReachedBranches.size();
+        double totalBranches = 44;
+        Double branchCoverage = 100 * ((double) coveredBranches / totalBranches);
+        System.out.println("From aftertest: " + coveredBranches);
+        try {
+                File directory = new File("./build/reports/tests/coverage");
+                directory.mkdirs();
+                FileWriter writer = new FileWriter("./build/reports/tests/coverage/getRecipientsOfQuestion.txt");
+                writer.write("Code coverage: " + branchCoverage.toString() + "%\n");
+                writer.write("Branches covered: ");
+                for (Integer i : frLogic.debugReachedBranches) {
+                        writer.write(i.toString() + " ");
+                }
+                writer.write("\nBranches not covered: ");
+                for (Integer i = 1; i < totalBranches; i++) {
+                        if (!Arrays.asList(frLogic.debugReachedBranches).contains(i)) {
+                                writer.write(i.toString() + " ");
+                        }
+                }
+                writer.write("\n");
+                writer.close();
+        } catch (IOException e) {
+                e.printStackTrace();
+        }
+    }    
 
     @Test
     public void testGetRecipientsOfQuestion() throws Exception {

--- a/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
+++ b/src/test/java/teammates/logic/core/FeedbackQuestionsLogicTest.java
@@ -22,6 +22,8 @@ import teammates.common.datatransfer.attributes.StudentAttributes;
 import teammates.common.datatransfer.questions.FeedbackMcqQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackMsqQuestionDetails;
 import teammates.common.datatransfer.questions.FeedbackQuestionDetails;
+import teammates.common.datatransfer.questions.FeedbackQuestionType;
+import teammates.common.datatransfer.questions.FeedbackResponseDetails;
 import teammates.common.datatransfer.questions.FeedbackTextQuestionDetails;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -821,6 +823,119 @@ public class FeedbackQuestionsLogicTest extends BaseLogicTest {
         fqLogic.populateFieldsToGenerateInQuestion(fqa, typicalInstructor.getEmail(), null);
         assertEquals(Arrays.asList("Team 1.1</td></div>'\"", "Team 1.2"),
                 ((FeedbackMsqQuestionDetails) fqa.getQuestionDetailsCopy()).getMsqChoices());
+    }
+
+    @Test
+    public void testPopulateFieldsToGenerateInQuestion_otherQuestion_fqaIsUnchanged() {
+        StudentAttributes typicalStudent = dataBundle.students.get("student1InCourse1");
+
+        FeedbackQuestionAttributes fqa = dataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
+        // construct a typical question
+        fqa = FeedbackQuestionAttributes.builder()
+                        .withCourseId(fqa.getCourseId())
+                        .withFeedbackSessionName(fqa.getFeedbackSessionName())
+                        .withNumberOfEntitiesToGiveFeedbackTo(2)
+                        .withQuestionDescription("test")
+                        .withQuestionNumber(fqa.getQuestionNumber())
+                        .withGiverType(FeedbackParticipantType.STUDENTS)
+                        .withRecipientType(FeedbackParticipantType.STUDENTS)
+                        .withQuestionDetails(new FeedbackTextQuestionDetails())
+                        .withShowResponsesTo(new ArrayList<>())
+                        .withShowGiverNameTo(new ArrayList<>())
+                        .withShowRecipientNameTo(new ArrayList<>())
+                        .build();
+
+        FeedbackQuestionAttributes identical_fqa = fqa.getCopy();
+
+        fqLogic.populateFieldsToGenerateInQuestion(fqa, typicalStudent.getEmail(), typicalStudent.getTeam());
+        assertEquals(fqa, identical_fqa);
+    }
+
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = "Course disappeared")
+    public void testPopulateFieldsToGenerateInQuestion_mcqQuestion_courseMissingThrowsAssertionError() {
+        StudentAttributes typicalStudent = dataBundle.students.get("student1InCourse1");
+
+        FeedbackQuestionAttributes fqa = dataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
+        // construct a typical question
+        fqa = FeedbackQuestionAttributes.builder()
+                        .withCourseId("nonExistantCourseId")
+                        .withFeedbackSessionName(fqa.getFeedbackSessionName())
+                        .withNumberOfEntitiesToGiveFeedbackTo(2)
+                        .withQuestionDescription("test")
+                        .withQuestionNumber(fqa.getQuestionNumber())
+                        .withGiverType(FeedbackParticipantType.STUDENTS)
+                        .withRecipientType(FeedbackParticipantType.STUDENTS)
+                        .withQuestionDetails(new FeedbackMcqQuestionDetails())
+                        .withShowResponsesTo(new ArrayList<>())
+                        .withShowGiverNameTo(new ArrayList<>())
+                        .withShowRecipientNameTo(new ArrayList<>())
+                        .build();
+
+        FeedbackMcqQuestionDetails feedbackMcqQuestionDetails = new FeedbackMcqQuestionDetails();
+
+        feedbackMcqQuestionDetails.setMcqChoices(Arrays.asList("test"));
+        feedbackMcqQuestionDetails.setGenerateOptionsFor(FeedbackParticipantType.TEAMS_EXCLUDING_SELF);
+        fqa.setQuestionDetails(feedbackMcqQuestionDetails);
+
+        fqLogic.populateFieldsToGenerateInQuestion(fqa, typicalStudent.getEmail(), typicalStudent.getTeam()); // Should result in an AssertionError
+    }
+
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = "Course disappeared")
+    public void testPopulateFieldsToGenerateInQuestion_msqQuestion_courseMissingThrowsAssertionError() {
+        StudentAttributes typicalStudent = dataBundle.students.get("student1InCourse1");
+
+        FeedbackQuestionAttributes fqa = dataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
+        // construct a typical question
+        fqa = FeedbackQuestionAttributes.builder()
+                        .withCourseId("nonExistantCourseId")
+                        .withFeedbackSessionName(fqa.getFeedbackSessionName())
+                        .withNumberOfEntitiesToGiveFeedbackTo(2)
+                        .withQuestionDescription("test")
+                        .withQuestionNumber(fqa.getQuestionNumber())
+                        .withGiverType(FeedbackParticipantType.STUDENTS)
+                        .withRecipientType(FeedbackParticipantType.STUDENTS)
+                        .withQuestionDetails(new FeedbackMsqQuestionDetails())
+                        .withShowResponsesTo(new ArrayList<>())
+                        .withShowGiverNameTo(new ArrayList<>())
+                        .withShowRecipientNameTo(new ArrayList<>())
+                        .build();
+
+        FeedbackMsqQuestionDetails feedbackMsqQuestionDetails = new FeedbackMsqQuestionDetails();
+
+        feedbackMsqQuestionDetails.setMsqChoices(Arrays.asList("test"));
+        feedbackMsqQuestionDetails.setGenerateOptionsFor(FeedbackParticipantType.TEAMS_EXCLUDING_SELF);
+        fqa.setQuestionDetails(feedbackMsqQuestionDetails);
+
+        fqLogic.populateFieldsToGenerateInQuestion(fqa, typicalStudent.getEmail(), typicalStudent.getTeam()); // Should result in an AssertionError
+    }
+
+    @Test(expectedExceptions = AssertionError.class, expectedExceptionsMessageRegExp = "Trying to generate options for neither students, teams nor instructors")
+    public void testPopulateFieldsToGenerateInQuestion_msqQuestion_generateOptionsForIsSelfThrowsAssertionError() {
+        StudentAttributes typicalStudent = dataBundle.students.get("student1InCourse1");
+
+        FeedbackQuestionAttributes fqa = dataBundle.feedbackQuestions.get("qn1InSession1InCourse1");
+        // construct a typical question
+        fqa = FeedbackQuestionAttributes.builder()
+                        .withCourseId(fqa.getCourseId())
+                        .withFeedbackSessionName(fqa.getFeedbackSessionName())
+                        .withNumberOfEntitiesToGiveFeedbackTo(2)
+                        .withQuestionDescription("test")
+                        .withQuestionNumber(fqa.getQuestionNumber())
+                        .withGiverType(FeedbackParticipantType.STUDENTS)
+                        .withRecipientType(FeedbackParticipantType.STUDENTS)
+                        .withQuestionDetails(new FeedbackMcqQuestionDetails())
+                        .withShowResponsesTo(new ArrayList<>())
+                        .withShowGiverNameTo(new ArrayList<>())
+                        .withShowRecipientNameTo(new ArrayList<>())
+                        .build();
+
+        FeedbackMsqQuestionDetails feedbackMcqQuestionDetails = new FeedbackMsqQuestionDetails();
+
+        feedbackMcqQuestionDetails.setMsqChoices(Arrays.asList("test"));
+        feedbackMcqQuestionDetails.setGenerateOptionsFor(FeedbackParticipantType.SELF); // Should trigger default case in generateOptionsFor switch
+        fqa.setQuestionDetails(feedbackMcqQuestionDetails);
+
+        fqLogic.populateFieldsToGenerateInQuestion(fqa, typicalStudent.getEmail(), typicalStudent.getTeam()); // Should result in an AssertionError
     }
 
     @Test


### PR DESCRIPTION
This adds lines to getRecipientsOfQuestion that store which branches were reached during the lifetime of an instance of the FeedbackQuestionsLogic class. 