### PR TITLE
Feat: Refactor populateFieldsToGenerateInQuestion

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -572,14 +572,13 @@ public final class FeedbackQuestionsLogic {
 
         FeedbackParticipantType generateOptionsFor;
 
+        // Create optionsList and generateOptionsFor
         if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MCQ) {
-            FeedbackMcqQuestionDetails feedbackMcqQuestionDetails =
-                    (FeedbackMcqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
+            FeedbackMcqQuestionDetails feedbackMcqQuestionDetails = (FeedbackMcqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
             optionList = feedbackMcqQuestionDetails.getMcqChoices();
             generateOptionsFor = feedbackMcqQuestionDetails.getGenerateOptionsFor();
         } else if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MSQ) {
-            FeedbackMsqQuestionDetails feedbackMsqQuestionDetails =
-                    (FeedbackMsqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
+            FeedbackMsqQuestionDetails feedbackMsqQuestionDetails = (FeedbackMsqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
             optionList = feedbackMsqQuestionDetails.getMsqChoices();
             generateOptionsFor = feedbackMsqQuestionDetails.getGenerateOptionsFor();
         } else {
@@ -587,68 +586,67 @@ public final class FeedbackQuestionsLogic {
             return;
         }
 
-        switch (generateOptionsFor) {
+        populateOptionList(optionList, generateOptionsFor, feedbackQuestionAttributes, emailOfEntityDoingQuestion, teamOfEntityDoingQuestion);
+
+        // Write optionList to feedbackQuestionAttributes
+        if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MCQ) {
+            FeedbackMcqQuestionDetails feedbackMcqQuestionDetails = (FeedbackMcqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
+            feedbackMcqQuestionDetails.setMcqChoices(optionList);
+            feedbackQuestionAttributes.setQuestionDetails(feedbackMcqQuestionDetails);
+        } else if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MSQ) {
+            FeedbackMsqQuestionDetails feedbackMsqQuestionDetails = (FeedbackMsqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
+            feedbackMsqQuestionDetails.setMsqChoices(optionList);
+            feedbackQuestionAttributes.setQuestionDetails(feedbackMsqQuestionDetails);
+        }
+    }
+
+    /**
+     * Helper function for populateFieldsToGenerateInQuestion that populates the given optionList
+     * @param optionList the optionList to populate
+     * @param generateOptionsFor the type of feedback participant to generate options for
+     * @param feedbackQuestionAttributes the question to populate
+     * @param emailOfEntityDoingQuestion the email of the entity doing the question
+     * @param teamOfEntityDoingQuestion the team of the entity doing the question.
+     * @throws AssertionError if the course specified in the feedback question attributes does not exist
+     * or when generateOptionsFor is neither a student, team or instructor
+     */
+    private void populateOptionList(
+        List<String> optionList,
+        FeedbackParticipantType generateOptionsFor,
+        FeedbackQuestionAttributes feedbackQuestionAttributes,
+        String emailOfEntityDoingQuestion,
+        String teamOfEntityDoingQuestion
+    ) {
+    switch (generateOptionsFor) {
         case NONE:
             break;
         case STUDENTS:
         case STUDENTS_IN_SAME_SECTION:
         case STUDENTS_EXCLUDING_SELF:
-            List<StudentAttributes> studentList;
-            if (generateOptionsFor == FeedbackParticipantType.STUDENTS_IN_SAME_SECTION) {
-                String courseId = feedbackQuestionAttributes.getCourseId();
-                StudentAttributes studentAttributes =
-                        studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
-                studentList = studentsLogic.getStudentsForSection(studentAttributes.getSection(), courseId);
-            } else {
-                studentList = studentsLogic.getStudentsForCourse(feedbackQuestionAttributes.getCourseId());
-            }
+            List<StudentAttributes> studentList = getStudentList(generateOptionsFor, feedbackQuestionAttributes, emailOfEntityDoingQuestion);
 
-            if (generateOptionsFor == FeedbackParticipantType.STUDENTS_EXCLUDING_SELF) {
-                studentList.removeIf(studentInList -> studentInList.getEmail().equals(emailOfEntityDoingQuestion));
-            }
-
-            for (StudentAttributes student : studentList) {
+            for (StudentAttributes student : studentList)
                 optionList.add(student.getName() + " (" + student.getTeam() + ")");
-            }
 
             optionList.sort(null);
             break;
         case TEAMS:
         case TEAMS_IN_SAME_SECTION:
         case TEAMS_EXCLUDING_SELF:
-            try {
-                List<String> teams;
-                if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
-                    String courseId = feedbackQuestionAttributes.getCourseId();
-                    StudentAttributes studentAttributes =
-                            studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
-                    teams = coursesLogic.getTeamsForSection(studentAttributes.getSection(), courseId);
-                } else {
-                    teams = coursesLogic.getTeamsForCourse(feedbackQuestionAttributes.getCourseId());
-                }
+            List<String> teams = getTeamList(generateOptionsFor, feedbackQuestionAttributes, emailOfEntityDoingQuestion, teamOfEntityDoingQuestion);
 
-                if (generateOptionsFor == FeedbackParticipantType.TEAMS_EXCLUDING_SELF) {
-                    teams.removeIf(team -> team.equals(teamOfEntityDoingQuestion));
-                }
+            for (String team : teams)
+                optionList.add(team);
 
-                for (String team : teams) {
-                    optionList.add(team);
-                }
-
-                optionList.sort(null);
-            } catch (EntityDoesNotExistException e) {
-                assert false : "Course disappeared";
-            }
+            optionList.sort(null);
             break;
         case OWN_TEAM_MEMBERS_INCLUDING_SELF:
         case OWN_TEAM_MEMBERS:
             if (teamOfEntityDoingQuestion != null) {
-                List<StudentAttributes> teamMembers = studentsLogic.getStudentsForTeam(teamOfEntityDoingQuestion,
-                        feedbackQuestionAttributes.getCourseId());
+                List<StudentAttributes> teamMembers = studentsLogic.getStudentsForTeam(teamOfEntityDoingQuestion, feedbackQuestionAttributes.getCourseId());
 
-                if (generateOptionsFor == FeedbackParticipantType.OWN_TEAM_MEMBERS) {
+                if (generateOptionsFor == FeedbackParticipantType.OWN_TEAM_MEMBERS)
                     teamMembers.removeIf(teamMember -> teamMember.getEmail().equals(emailOfEntityDoingQuestion));
-                }
 
                 teamMembers.forEach(teamMember -> optionList.add(teamMember.getName()));
 
@@ -656,12 +654,10 @@ public final class FeedbackQuestionsLogic {
             }
             break;
         case INSTRUCTORS:
-            List<InstructorAttributes> instructorList =
-                    instructorsLogic.getInstructorsForCourse(feedbackQuestionAttributes.getCourseId());
+            List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForCourse(feedbackQuestionAttributes.getCourseId());
 
-            for (InstructorAttributes instructor : instructorList) {
+            for (InstructorAttributes instructor : instructorList)
                 optionList.add(instructor.getName());
-            }
 
             optionList.sort(null);
             break;
@@ -669,17 +665,67 @@ public final class FeedbackQuestionsLogic {
             assert false : "Trying to generate options for neither students, teams nor instructors";
             break;
         }
+    }
 
-        if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MCQ) {
-            FeedbackMcqQuestionDetails feedbackMcqQuestionDetails =
-                    (FeedbackMcqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
-            feedbackMcqQuestionDetails.setMcqChoices(optionList);
-            feedbackQuestionAttributes.setQuestionDetails(feedbackMcqQuestionDetails);
-        } else if (feedbackQuestionAttributes.getQuestionType() == FeedbackQuestionType.MSQ) {
-            FeedbackMsqQuestionDetails feedbackMsqQuestionDetails =
-                    (FeedbackMsqQuestionDetails) feedbackQuestionAttributes.getQuestionDetailsCopy();
-            feedbackMsqQuestionDetails.setMsqChoices(optionList);
-            feedbackQuestionAttributes.setQuestionDetails(feedbackMsqQuestionDetails);
+    /**
+     * Returns a list of student names based on the given feedback participant type, feedback question attributes and email of the entity doing the question
+     * @param generateOptionsFor the type of feedback participant to generate options for
+     * @param feedbackQuestionAttributes the question to populate
+     * @param emailOfEntityDoingQuestion the email of the entity doing the question
+     * @return a list of student names
+     */
+    private List<StudentAttributes> getStudentList(
+        FeedbackParticipantType generateOptionsFor,
+        FeedbackQuestionAttributes feedbackQuestionAttributes,
+        String emailOfEntityDoingQuestion
+    ) {
+        List<StudentAttributes> studentList;
+        if (generateOptionsFor == FeedbackParticipantType.STUDENTS_IN_SAME_SECTION) {
+            String courseId = feedbackQuestionAttributes.getCourseId();
+            StudentAttributes studentAttributes =
+                    studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
+            studentList = studentsLogic.getStudentsForSection(studentAttributes.getSection(), courseId);
+        } else
+            studentList = studentsLogic.getStudentsForCourse(feedbackQuestionAttributes.getCourseId());
+
+        if (generateOptionsFor == FeedbackParticipantType.STUDENTS_EXCLUDING_SELF)
+            studentList.removeIf(studentInList -> studentInList.getEmail().equals(emailOfEntityDoingQuestion));
+        return studentList;
+    }
+
+    /**
+     * Returns a list of team names based on the given feedback participant type, feedback question attributes, email of the entity doing the question,
+     * and team of the entity doing the question.
+     * @param generateOptionsFor the type of feedback participant to generate options for
+     * @param feedbackQuestionAttributes the question to populate
+     * @param emailOfEntityDoingQuestion the email of the entity doing the question
+     * @param teamOfEntityDoingQuestion the team of the entity doing the question.
+     * @return a list of team names
+     * @throws AssertionError if the course specified in the feedback question attributes does not exist
+     */
+    private List<String> getTeamList(
+        FeedbackParticipantType generateOptionsFor,
+        FeedbackQuestionAttributes feedbackQuestionAttributes,
+        String emailOfEntityDoingQuestion,
+        String teamOfEntityDoingQuestion
+    ) {
+        try {
+            List<String> teams;
+            if (generateOptionsFor == FeedbackParticipantType.TEAMS_IN_SAME_SECTION) {
+                String courseId = feedbackQuestionAttributes.getCourseId();
+                StudentAttributes studentAttributes =
+                        studentsLogic.getStudentForEmail(courseId, emailOfEntityDoingQuestion);
+                teams = coursesLogic.getTeamsForSection(studentAttributes.getSection(), courseId);
+            } else
+                teams = coursesLogic.getTeamsForCourse(feedbackQuestionAttributes.getCourseId());
+
+            if (generateOptionsFor == FeedbackParticipantType.TEAMS_EXCLUDING_SELF)
+                teams.removeIf(team -> team.equals(teamOfEntityDoingQuestion));
+            
+            return teams;
+        } catch (EntityDoesNotExistException e) {
+            assert false : "Course disappeared";
+            return Collections.emptyList(); // Unreachable
         }
     }
 


### PR DESCRIPTION
This splits the populateFieldsToGenerateInQuestion into four methods with lower cyclomatic complexity. These functions are populateFieldsToGenerateInQuestion, populateOptionList, getStudentList and getTeamList with CC:s of 5, 11, 3 and 3, respectively. Compared to the previous CC of 19, populateFieldsToGenerateInQuestion has had its complexity reduced by 74%. The most complex of the new methods, populateOptionList, also has a CC that is 42% lower than the original method.

Fixes #26